### PR TITLE
Replace futures with subcrates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,10 @@ keywords = ["async", "stream"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-futures = "0.3"
+futures-util = { version = "0.3", default-features = false, features = ["std"] }
 pin-project-lite = "0.2"
 
 [dev-dependencies]
 anyhow = "1"
+futures-executor = { version = "0.3", default-features = false, features = ["std", "thread-pool"] }
 tokio = { version = "1.0", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Finite stream of numbers
 
 ```rust
 use async_fn_stream::fn_stream;
-use futures::Stream;
+use futures_util::Stream;
 
 fn build_stream() -> impl Stream<Item = i32> {
     fn_stream(|emitter| async move {
@@ -39,7 +39,7 @@ Read numbers from text file, with error handling
 ```rust
 use anyhow::Context;
 use async_fn_stream::try_fn_stream;
-use futures::{pin_mut, Stream, StreamExt};
+use futures_util::{pin_mut, Stream, StreamExt};
 use tokio::{
     fs::File,
     io::{AsyncBufReadExt, BufReader},

--- a/examples/file_numbers.rs
+++ b/examples/file_numbers.rs
@@ -2,7 +2,7 @@ use std::env::args;
 
 use anyhow::Context;
 use async_fn_stream::try_fn_stream;
-use futures::{pin_mut, Stream, StreamExt};
+use futures_util::{pin_mut, Stream, StreamExt};
 use tokio::{
     fs::File,
     io::{AsyncBufReadExt, BufReader},

--- a/examples/numbers.rs
+++ b/examples/numbers.rs
@@ -1,5 +1,5 @@
 use async_fn_stream::fn_stream;
-use futures::{pin_mut, Stream, StreamExt};
+use futures_util::{pin_mut, Stream, StreamExt};
 
 fn build_stream() -> impl Stream<Item = i32> {
     fn_stream(|emitter| async move {
@@ -24,5 +24,5 @@ async fn example() {
 }
 
 pub fn main() {
-    futures::executor::block_on(example());
+    futures_executor::block_on(example());
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,7 +307,6 @@ impl Future for CollectFuture {
 mod tests {
     use std::io::ErrorKind;
 
-    use futures_executor;
     use futures_util::{pin_mut, StreamExt};
 
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //!
 //! ```rust
 //! use async_fn_stream::fn_stream;
-//! use futures::Stream;
+//! use futures_util::Stream;
 //!
 //! fn build_stream() -> impl Stream<Item = i32> {
 //!     fn_stream(|emitter| async move {
@@ -39,7 +39,7 @@
 //! ```rust
 //! use anyhow::Context;
 //! use async_fn_stream::try_fn_stream;
-//! use futures::{pin_mut, Stream, StreamExt};
+//! use futures_util::{pin_mut, Stream, StreamExt};
 //! use tokio::{
 //!     fs::File,
 //!     io::{AsyncBufReadExt, BufReader},
@@ -89,7 +89,7 @@ use std::{
     task::{Poll, Waker},
 };
 
-use futures::{Future, FutureExt, Stream};
+use futures_util::{Future, FutureExt, Stream};
 use pin_project_lite::pin_project;
 
 /// An intemediary that transfers values from stream to its consumer
@@ -119,7 +119,7 @@ pin_project! {
 ///
 /// ```rust
 /// use async_fn_stream::fn_stream;
-/// use futures::Stream;
+/// use futures_util::Stream;
 ///
 /// fn build_stream() -> impl Stream<Item = i32> {
 ///     fn_stream(|emitter| async move {
@@ -181,7 +181,7 @@ impl<T, Fut: Future<Output = ()>> Stream for FnStream<T, Fut> {
 /// # Example
 /// ```rust
 /// use async_fn_stream::try_fn_stream;
-/// use futures::Stream;
+/// use futures_util::Stream;
 ///
 /// fn build_stream() -> impl Stream<Item = Result<i32, anyhow::Error>> {
 ///     try_fn_stream(|emitter| async move {
@@ -260,7 +260,7 @@ impl<T, E, Fut: Future<Output = Result<(), E>>> Stream for TryFnStream<T, E, Fut
 }
 
 impl<T> StreamEmitter<T> {
-    /// Emit value from a stream and wait until stream consumer calls [`futures::StreamExt::next`] again.
+    /// Emit value from a stream and wait until stream consumer calls [`futures_util::StreamExt::next`] again.
     ///
     /// # Panics
     /// Will panic if:
@@ -307,13 +307,14 @@ impl Future for CollectFuture {
 mod tests {
     use std::io::ErrorKind;
 
-    use futures::{executor, pin_mut, StreamExt};
+    use futures_executor;
+    use futures_util::{pin_mut, StreamExt};
 
     use super::*;
 
     #[test]
     fn infallible_works() {
-        executor::block_on(async {
+        futures_executor::block_on(async {
             let stream = fn_stream(|collector| async move {
                 eprintln!("stream 1");
                 collector.emit(1).await;
@@ -331,7 +332,7 @@ mod tests {
     #[test]
     fn infallible_lifetime() {
         let a = 1;
-        executor::block_on(async {
+        futures_executor::block_on(async {
             let b = 2;
             let a = &a;
             let b = &b;
@@ -352,7 +353,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn infallible_panics_on_multiple_collects() {
-        executor::block_on(async {
+        futures_executor::block_on(async {
             #[allow(unused_must_use)]
             let stream = fn_stream(|collector| async move {
                 eprintln!("stream 1");
@@ -369,7 +370,7 @@ mod tests {
 
     #[test]
     fn fallible_works() {
-        executor::block_on(async {
+        futures_executor::block_on(async {
             let stream = try_fn_stream(|collector| async move {
                 eprintln!("try stream 1");
                 collector.emit(1).await;
@@ -405,7 +406,7 @@ mod tests {
             }
         }
 
-        executor::block_on(async {
+        futures_executor::block_on(async {
             let l = St {
                 a: "qwe".to_owned(),
             };


### PR DESCRIPTION
Hi. Instead of using the whole futures module, it is better to use pointwise its subcrates, thus making the module more compact.