### PR TITLE
feat: improve support for concurrency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ pedantic = "deny"
 [dependencies]
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
 pin-project-lite = "0.2"
+smallvec = "1.15.1"
 
 [dev-dependencies]
 anyhow = "1"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ To create a stream:
    This will end the stream.
 2. An `emitter` also has an `emit_err()` method to return errors without ending the stream.
 
+## Limitations
+
+`fn_stream` does not support cross-task streams, that is all stream values must be produced in the same task as the stream.
+Specifically, it is not supported to move `StreamEmitter` to another thread or tokio task.
+If your use case necessitates this, consider using async chanells for that.
+
+## Advanced usage
+
+Internal concurrency is supported within `fn_stream` (see [examples/join.rs](examples/join.rs)).
+
 # Examples
 
 Finite stream of numbers

--- a/examples/join.rs
+++ b/examples/join.rs
@@ -1,0 +1,40 @@
+use async_fn_stream::fn_stream;
+use futures_util::{pin_mut, Stream, StreamExt};
+
+fn build_stream() -> impl Stream<Item = i32> {
+    fn_stream(|emitter| async move {
+        tokio::join!(
+            async {
+                for i in 0..3 {
+                    // yield elements from stream via `collector`
+                    emitter.emit(i).await;
+                }
+            },
+            async {
+                for i in 10..13 {
+                    // yield elements from stream via `collector`
+                    emitter.emit(i).await;
+                }
+            }
+        );
+    })
+}
+
+async fn example() {
+    let stream = build_stream();
+
+    pin_mut!(stream);
+    let mut numbers = Vec::new();
+    while let Some(number) = stream.next().await {
+        print!("{number} ");
+        numbers.push(number);
+    }
+    println!();
+    numbers.sort_unstable();
+    assert_eq!(numbers, vec![0, 1, 2, 10, 11, 12]);
+}
+
+#[tokio::main]
+async fn main() {
+    futures_executor::block_on(example());
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,10 +265,11 @@ impl<T> Future for CollectFuture<'_, T> {
             }
             let value = this.value.take().expect("due to `this.value.is_some()`");
             inner.value = Some(value);
+            // inner.waker is `Some` only for duration of a single `FnStream::poll()` call, which helps detecting invalid usage
             inner
                 .waker
                 .as_ref()
-                .expect("emit() should only be called in context of Future::poll()")
+                .expect("StreamEmitter::emit().await should only be called in context of `fn_stream()`/`try_fn_stream()`")
                 .wake_by_ref();
             drop(inner_guard);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,7 +198,7 @@ impl<T> StreamEmitter<T> {
     /// * `emit` is called twice without awaiting result of first call
     /// * `emit` is called not in context of polling the stream
     #[must_use = "Ensure that emit() is awaited"]
-    pub fn emit(&self, value: T) -> CollectFuture<T> {
+    pub fn emit(&'_ self, value: T) -> CollectFuture<'_, T> {
         CollectFuture::new(&self.inner, value)
     }
 }
@@ -211,7 +211,7 @@ impl<T, E> TryStreamEmitter<T, E> {
     /// * `emit`/`emit_err` is called twice without awaiting result of the first call
     /// * `emit` is called not in context of polling the stream
     #[must_use = "Ensure that emit() is awaited"]
-    pub fn emit(&self, value: T) -> CollectFuture<Result<T, E>> {
+    pub fn emit(&'_ self, value: T) -> CollectFuture<'_, Result<T, E>> {
         CollectFuture::new(&self.inner, Ok(value))
     }
 
@@ -222,7 +222,7 @@ impl<T, E> TryStreamEmitter<T, E> {
     /// * `emit`/`emit_err` is called twice without awaiting result of the first call
     /// * `emit_err` is called not in context of polling the stream
     #[must_use = "Ensure that emit_err() is awaited"]
-    pub fn emit_err(&self, err: E) -> CollectFuture<Result<T, E>> {
+    pub fn emit_err(&'_ self, err: E) -> CollectFuture<'_, Result<T, E>> {
         CollectFuture::new(&self.inner, Err(err))
     }
 }


### PR DESCRIPTION
- support for internal concurrency within stream (e.g., using `tokio::join` or `FuturesUnordered`)
- dynamic check against cross-executor usage of `StreamEmitter`
- reduce spurious wakeups
  - for basic usage
  - for `FuturesUnordered`
- TODO: static check against cross-executor usage of `StreamEmitter`
  - emitter as a reference
- TODO: remove Arc
  - create emitter and call closure after pinning the future?