### PR TITLE
perf: don't use mutex

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -33,3 +33,10 @@ jobs:
       - name: Install rust (stable)
         uses: dtolnay/rust-toolchain@stable
       - run: cargo test --all-targets --workspace
+  test-miri:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install rust (nightly)
+        uses: dtolnay/rust-toolchain@nightly
+      - run: cargo miri test --all-targets --workspace


### PR DESCRIPTION
For trivial use cases, Mutex shows up in flamegraphs. We can avoid using it since it's only valid to access the emitter from within the stream's closure.