### PR TITLE
feat: support `emit_result` for `try_fn_stream`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -546,7 +546,7 @@ mod tests {
                     .await;
                 eprintln!("try stream 4");
                 emitter
-                    .emit_err(std::io::Error::from(ErrorKind::Other))
+                    .emit_result(Err(std::io::Error::from(ErrorKind::Other)))
                     .await;
                 eprintln!("try stream 5");
                 Err(std::io::Error::from(ErrorKind::Other))


### PR DESCRIPTION
relates to https://github.com/dmitryvk/async-fn-stream/issues/15